### PR TITLE
Eliminate one intermediate packaged_task on non-MSVC

### DIFF
--- a/include/task_thread_pool.hpp
+++ b/include/task_thread_pool.hpp
@@ -90,7 +90,7 @@
 // Version macros.
 #define TASK_THREAD_POOL_VERSION_MAJOR 1
 #define TASK_THREAD_POOL_VERSION_MINOR 0
-#define TASK_THREAD_POOL_VERSION_PATCH 9
+#define TASK_THREAD_POOL_VERSION_PATCH 10
 
 #include <condition_variable>
 #include <functional>

--- a/include/task_thread_pool.hpp
+++ b/include/task_thread_pool.hpp
@@ -279,10 +279,18 @@ namespace task_thread_pool {
 #endif
             >
         TTP_NODISCARD std::future<R> submit(F&& func, A&&... args) {
+#if defined(_MSVC_LANG)
+            // MSVC's packaged_task is not movable.
             std::shared_ptr<std::packaged_task<R()>> ptask =
                 std::make_shared<std::packaged_task<R()>>(std::bind(std::forward<F>(func), std::forward<A>(args)...));
             submit_detach([ptask] { (*ptask)(); });
             return ptask->get_future();
+#else
+            std::packaged_task<R()> task(std::bind(std::forward<F>(func), std::forward<A>(args)...));
+            auto ret = task.get_future();
+            submit_detach(std::move(task));
+            return ret;
+#endif
         }
 
         /**


### PR DESCRIPTION
Omit the shared_ptr on platforms that support moving std::packaged_task. This allows the compiler to not emit quite a lot of symbols for this task.

MSVC does not support moving std::packaged_task, so old behavior is kept there.
See https://developercommunity.visualstudio.com/t/unable-to-move-stdpackaged-task-into-any-stl-conta/108672